### PR TITLE
Formalisation des TYPES utilisables dans un enum

### DIFF
--- a/apps/kernelconcept/urls.py
+++ b/apps/kernelconcept/urls.py
@@ -1,20 +1,20 @@
 from django.conf.urls import url
 
-from apps.utils import parse_url
+from apps.utils import parse_url, TYPES
 
 from . import views
 
 urlpatterns = [
     url(
         parse_url('^users/', params={
-            'user_id': 'numbers'
+            'user_id': TYPES.NUMBERS
         }),
         views.detail,
         name='users-detail',
     ),
     url(
         parse_url('^users/', params={
-            'user_search': '*'
+            'user_search': TYPES.ALL
         }),
         views.search,
         name='users-search',

--- a/apps/utils/__init__.py
+++ b/apps/utils/__init__.py
@@ -1,4 +1,13 @@
-def parse_url(path: str, params: dict = None) -> str:
+from enum import Enum, auto
+
+
+class TYPES(Enum):
+    NUMBERS = auto()
+    CHARS = auto()
+    ALL = auto()  # but not /
+
+
+def parse_url(path: str = '^/', params: dict = {}) -> str:
     """
     This function is an url parser that simplifies URL writing
     by automatically formatting a simple string (with given
@@ -9,12 +18,17 @@ def parse_url(path: str, params: dict = None) -> str:
     :return: "Djangofied" url.
     """
 
-    if params:
-        for key, value in params:
-            if value == 'numbers':
-                path += '/(?P<{}>[0-9]+)'.format(key)
-            elif value == 'chars':
-                path += '/(?P<{}>[a-Z]+)'.format(key)
-            elif value == '*':
-                path += '/(?P<{}>.*)'.format(key)
+    last_char = str[-1:]
+    first = '' if last_char == '/' else '/'
+
+    for key, value in params:
+        if value is TYPES.NUMBERS:
+            path += '{}(?P<{}>[0-9]+)'.format(first, key)
+        elif value is TYPES.CHARS:
+            path += '{}(?P<{}>[A-z]+)'.format(first, key)
+        elif value is TYPES.ALL:
+            path += '{}(?P<{}>.*)'.format(first, key)
+        else:
+            path += '{}(?P<{}>{})'.format(first, key, value)
+
     return path


### PR DESCRIPTION
+ arguments par défaut
+ regex perso possible dans les values de params
~ fix des doubles /
~ fix de la regex de TYPES.CHARS les majuscules sont avant les minuscules donc c'est [A-z]et pas [a-Z]
  de plus il faut bien penser que [A-z] inclus les caractères suivants : [\]^_`